### PR TITLE
 Fix the issue with two camera streams in filters demo.

### DIFF
--- a/samples/camera/js/ui.js
+++ b/samples/camera/js/ui.js
@@ -128,6 +128,7 @@ function initUI() {
       videoConstraint.deviceId = { exact: controls.frontCamera.deviceId };
       facingModeButton.innerText = 'camera_rear';
     }
+    utils.clearError();
     utils.stopCamera();
     utils.startCamera(videoConstraint, 'videoInput', startCameraProcessing);
   });

--- a/samples/faceDetection/index.js
+++ b/samples/faceDetection/index.js
@@ -172,6 +172,7 @@ function initUI() {
       videoConstraint.deviceId = { exact: controls.frontCamera.deviceId };
       facingModeButton.innerText = 'camera_rear';
     }
+    utils.clearError();
     utils.stopCamera();
     utils.startCamera(videoConstraint, 'videoInput', startVideoProcessing);
   });

--- a/samples/filters/index.html
+++ b/samples/filters/index.html
@@ -192,8 +192,7 @@
       <input id="hideStats" class="hidden" type="checkbox" checked>
     </div>
   </div>
-  <video id="videoInputMain" class="hidden"></video>
-  <video id="videoInputSmall" class="hidden"></video>
+  <video id="videoInput" class="hidden"></video>
 
   <script src="../../libs/stats.min.js" type="text/javascript"></script>
   <script src="../../libs/adapter-latest.js" type="text/javascript"></script>

--- a/samples/filters/js/ui.js
+++ b/samples/filters/js/ui.js
@@ -25,7 +25,6 @@ function initUI() {
   let menuHeight = parseInt(getComputedStyle(
     document.querySelector('.camera-bar-wrapper')).height);
   getVideoConstraint(menuHeight);
-  calculateSmallVideoConstraint();
   initStats();
 
   controls = {
@@ -108,10 +107,6 @@ function initUI() {
     drawCanvas(dstCanvas, canvasOutput);
   });
 
-  // Set initial facingMode value for small video.
-  if (controls.backCamera != null) {
-    smallVideoConstraint.facingMode = controls.facingMode;
-  }
   // TODO(sasha): move to utils.js.
   let facingModeButton = document.getElementById('facingModeButton');
   // Switch to face or environment mode by clicking facingModeButton.
@@ -119,37 +114,16 @@ function initUI() {
     if (controls.facingMode == 'user') {
       controls.facingMode = 'environment';
       videoConstraint.deviceId = { exact: controls.backCamera.deviceId };
-      smallVideoConstraint.deviceId = { exact: controls.backCamera.deviceId };
       facingModeButton.innerText = 'camera_front';
     } else if (controls.facingMode == 'environment') {
       controls.facingMode = 'user';
       videoConstraint.deviceId = { exact: controls.frontCamera.deviceId };
-      smallVideoConstraint.deviceId = { exact: controls.frontCamera.deviceId };
       facingModeButton.innerText = 'camera_rear';
     }
-    stopCamera(video);
-    stopCamera(videoSmall);
-    utils.startCamera(videoConstraint, 'videoInputMain', () => {
-      // TODO(sasha): figure out why some cameras don't work
-      // if we create two streams.
-      utils.startCamera(smallVideoConstraint,
-        'videoInputSmall', startVideoProcessing);
-    });
+    utils.clearError();
+    utils.stopCamera();
+    utils.startCamera(videoConstraint, 'videoInput', startVideoProcessing);
   });
-}
-
-function calculateSmallVideoConstraint() {
-  if (isMobileDevice()) {
-    smallVideoConstraint = {
-      width: { ideal: parseInt(window.screen.width / 5) },
-      height: { ideal: parseInt(window.screen.width / 5) }
-    };
-  } else { // Create 5 times lower square resolution.
-    smallVideoConstraint = {
-      width: { ideal: parseInt(videoConstraint.height.exact / 5) },
-      height: { ideal: parseInt(videoConstraint.height.exact / 5) }
-    };
-  }
 }
 
 function setFilter(filter) {
@@ -210,7 +184,7 @@ function initMenuLabels() {
   let fontSize;
   if (video.width >= 500) fontSize = `16px`;
   else if (video.width >= 400) fontSize = `14px`;
-  else if (video.width >= 300) fontSize = `12px`;
+  else if (video.width >= 300) fontSize = `10px`;
   else fontSize = `10px`;
   carousels.forEach(function (carousel) {
     carousel.style.fontSize = fontSize;

--- a/samples/funnyHats/js/ui.js
+++ b/samples/funnyHats/js/ui.js
@@ -137,6 +137,7 @@ function initUI() {
       videoConstraint.deviceId = { exact: controls.frontCamera.deviceId };
       facingModeButton.innerText = 'camera_rear';
     }
+    utils.clearError();
     utils.stopCamera();
     utils.startCamera(videoConstraint, 'videoInput', startVideoProcessing);
   });

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -179,6 +179,8 @@ function isMobileDevice() {
 };
 
 function getVideoConstraint(menuHeight) {
+  menuHeight = menuHeight + 120; // Add 120 pixels for browser panel.
+
   if (isMobileDevice()) {
     // TODO(sasha): figure out why getUserMedia(...) in utils.js
     // swap width and height for mobile devices.


### PR DESCRIPTION
Now we use one stream which we resize with canvasContext.drawImage(..) function. We put resized image to extra canvas and then use this canvas context for processing of filtered previews.

The performance is still the same.

See drawImage(..) description [here](https://www.w3schools.com/tags/canvas_drawimage.asp).